### PR TITLE
Fix statemachine import in payments service

### DIFF
--- a/services/payments-python/payments/main.py
+++ b/services/payments-python/payments/main.py
@@ -22,7 +22,7 @@ import structlog
 from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
-from transitions import State, StateMachine
+from statemachine import StateMachine, State
 
 # Import generated gRPC stubs
 from .pb import payments_pb2 as payment_pb2

--- a/services/payments-python/requirements.txt
+++ b/services/payments-python/requirements.txt
@@ -8,4 +8,4 @@ structlog
 opentelemetry-api
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-grpc
-transitions==0.9.0
+python-statemachine


### PR DESCRIPTION
## Summary
- fix import of StateMachine by switching from `transitions` to `python-statemachine`
- update dependencies accordingly

## Testing
- `pip install python-statemachine`
- `python -m py_compile services/payments-python/payments/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b607ee6b88832487eee1d6f9c146b2